### PR TITLE
Fix issue with padding for button component

### DIFF
--- a/lib/octantis_web/live/components/polaris/button.ex
+++ b/lib/octantis_web/live/components/polaris/button.ex
@@ -4,8 +4,14 @@ defmodule OctantisWeb.Components.Polaris.Button do
 
   ## Examples
   ```elixir
-  <.button>
-    Add product
+  <.button content="Save" />
+
+  <.button content="Delete">
+    <:icon><Icons.delete /></:icon>
+  </.button>
+
+  <.button variant="primary">
+    <:icon><Icons.delete /></:icon>
   </.button>
   ```
 
@@ -147,10 +153,10 @@ defmodule OctantisWeb.Components.Polaris.Button do
   defp button_class({_key, _value}), do: []
 
   defp assign_icon_status(assigns = %{icon: icon, content: content})
-       when not is_nil(icon) and not is_nil(content),
+       when is_list(icon) and icon != [] and not is_nil(content),
        do: assign(assigns, :icon_status, :icon_with_text)
 
-  defp assign_icon_status(assigns = %{icon: icon}) when not is_nil(icon),
+  defp assign_icon_status(assigns = %{icon: icon}) when is_list(icon) and icon != [],
     do: assign(assigns, :icon_status, :icon_only)
 
   defp assign_icon_status(assigns), do: assign(assigns, :icon_status, :text_only)


### PR DESCRIPTION
Empty icon slot is represented as an empty list, not nil.

Here how it looks after:

<img width="454" height="226" alt="image" src="https://github.com/user-attachments/assets/7d0368e6-2f97-4eda-a5a5-c839c015ab0b" />
